### PR TITLE
매칭이 제대로 되지 않는 현상 수정

### DIFF
--- a/src/main/java/me/lkh/hometownleague/DocController.java
+++ b/src/main/java/me/lkh/hometownleague/DocController.java
@@ -1,7 +1,12 @@
 package me.lkh.hometownleague;
 
+import me.lkh.hometownleague.schedule.matching.service.MatchMakingService;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 프론트엔드 개발자에게 문서를 쉽게 공유하기 위해 만든 Controller
@@ -9,6 +14,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("/rest")
 public class DocController {
+
+    private final MatchMakingService matchMakingService;
+
+    public DocController(MatchMakingService matchMakingService) {
+        this.matchMakingService = matchMakingService;
+    }
 
     /**
      * Rest Docs로 만든 api 명세서를 응답한다.
@@ -19,4 +30,17 @@ public class DocController {
         return "HometownLeagueApiDoc";
     }
 
+    /**
+     * 매칭 배치
+     * @return
+     */
+    @PostMapping("/batch")
+    public Map<String, String> matchingBatch(){
+
+        matchMakingService.matchMakingJob();
+
+        Map<String, String> result = new HashMap<>();
+        result.put("CODE", "SUCCESS");
+        return result;
+    }
 }

--- a/src/main/java/me/lkh/hometownleague/schedule/matching/service/MatchMakingService.java
+++ b/src/main/java/me/lkh/hometownleague/schedule/matching/service/MatchMakingService.java
@@ -65,7 +65,7 @@ public class MatchMakingService {
                     if(matchingStep(matchingRequestInfo, times)){
                         return ;
                     }
-
+                    times++;
                 }
 
                 // 3. 최대횟수 안에 매칭이 실패하면 최우선순위로 다시 넣고 종료
@@ -234,14 +234,4 @@ public class MatchMakingService {
         return null;
     }
 
-    @Override
-    public String toString() {
-        return "MatchMakingService{" +
-                "matchingRedisService=" + matchingRedisService +
-                ", matchMakingRepository=" + matchMakingRepository +
-                ", locationFilteringStrategy=" + locationFilteringStrategy +
-                ", maxNumber=" + maxNumber +
-                ", maxDistance=" + maxDistance +
-                '}';
-    }
 }

--- a/src/main/java/me/lkh/hometownleague/schedule/matching/service/location/impl/CoordinateFilter.java
+++ b/src/main/java/me/lkh/hometownleague/schedule/matching/service/location/impl/CoordinateFilter.java
@@ -41,7 +41,8 @@ public class CoordinateFilter implements LocationFilteringStrategy {
                     // 최대 거리차이보다 거리 차이가 작으면 해시맵에 추가
                     double distance = LocationUtil.getDistance(myTeamMatchingLocation.getLatitude(), myTeamMatchingLocation.getLongitude(), teamMatchingLocation.getLatitude(), teamMatchingLocation.getLongitude());
                     if (distanceDiff >= distance) {
-                        countMap.put(myTeamMatchingLocation.getTeamId(), distance);
+//                        countMap.put(myTeamMatchingLocation.getTeamId(), distance);
+                        countMap.put(teamMatchingLocation.getTeamId(), distance);
                     }
                 }
             }


### PR DESCRIPTION
1. 좌표기반 필터링 후 우리팀 ID가 아닌 상대팀 ID를 넣도록 수정
2. 매칭배치를 단건으로 돌려볼 수 있는 테스트 API개발
3. 특정 회수 이상 시도하고 없으면 종료되도록 수정